### PR TITLE
Remove shim

### DIFF
--- a/spec/nerdbox/nerdbox_spec.js
+++ b/spec/nerdbox/nerdbox_spec.js
@@ -209,9 +209,7 @@ describe('Nerdbox', function() {
         var nerdbox = new Nerdbox();
         $('.nerdbox').click();
 
-        // [0] here refers to the first element of the ones that have been selected.
-        // Nerdbox currently has two selectors (eg .nb-shim), so just use the first one.
-        expect($($(Nerdbox.options.contentSelector)[0])).toHaveText('Nerdbox Content');
+        expect($(Nerdbox.options.contentSelector)).toHaveText('Nerdbox Content');
       });
 
       it('can handle fragments as a substring', function() {
@@ -220,9 +218,7 @@ describe('Nerdbox', function() {
         var nerdbox = new Nerdbox();
         $('.nerdbox').click();
 
-        // [0] here refers to the first element of the ones that have been selected.
-        // Nerdbox currently has two selectors (eg .nb-shim), so just use the first one.
-        expect($($(Nerdbox.options.contentSelector)[0])).toHaveText('Nerdbox Content');
+        expect($(Nerdbox.options.contentSelector)).toHaveText('Nerdbox Content');
       });
     });
 
@@ -406,7 +402,7 @@ describe('Nerdbox', function() {
           Nerdbox.open($el);
 
           expect($('body > .element').length).toEqual(1);
-          expect($('body .element').length).toEqual(3); // 2 would be expected, plus nb-shim
+          expect($('body .element').length).toEqual(2);
           $el.remove();
         });
       });
@@ -417,9 +413,7 @@ describe('Nerdbox', function() {
 
           Nerdbox.open('#fragment');
 
-          // [0] here refers to the first element of the ones that have been selected.
-          // Nerdbox currently has two selectors (eg .nb-shim), so just use the first one.
-          expect($($(Nerdbox.options.contentSelector)[0])).toHaveText('Nerdbox Content');
+          expect($(Nerdbox.options.contentSelector)).toHaveText('Nerdbox Content');
           $('#fragment').remove();
         });
       });

--- a/src/nerdbox.css
+++ b/src/nerdbox.css
@@ -81,15 +81,11 @@
   line-height: 20px;
 }
 
-#nerdbox .nb-shim {
-  visibility: hidden;
-}
-
 #nerdbox .nb-content {
   background: #FFF;
   height: 100%;
   width: 100%;
-  position: absolute;
+  /*position: absolute;*/
   top: 0;
   left: 0;
   overflow: auto;

--- a/src/nerdbox.js
+++ b/src/nerdbox.js
@@ -22,14 +22,13 @@ Nerdbox.options = {
   imageExts       : [ 'png', 'jpg', 'jpeg', 'gif' ],
   nerdboxSelector : '#nerdbox',
   overlaySelector : '.nb-overlay',
-  contentSelector : '.nb-content, .nb-shim',
+  contentSelector : '.nb-content',
   closeSelector   : '.nb-close',
   container       : '\
 <div id="nerdbox" style="display: none;"> \
   <div class="nb-overlay"></div> \
   <div class="nb-wrapper"> \
     <div class="nb-content"></div> \
-    <div class="nb-shim"></div> \
     <a href="#" class="nb-close" title="close"></a> \
   </div> \
 </div>',


### PR DESCRIPTION
There's one major problem facing Nerdbox: overflow. It's difficult to allow the lightbox to collapse on the content and center when it's smaller than the current window, but grow and overflow when the content is larger than the window, to some threshold/margin. The scrollbars should be inside the lightbox, but the window shouldn't scroll.

My understanding of the problem: the browser can't vertically center the lightbox without being able to calculate it's child's height. When overflowing, it fails to calculate the content's height properly within the lightbox. One way to solve this is with a "shim", where we append the same content to a sibling element to the content container, so that the content container can calculate it's maximum height, and hence provide scrollbars when overflowing. The problem is in order for the content container to know its height, we have to duplicate the content inside the shim. Obviously bad.

This pull request is to remove the shim and provide a sane overflow without it. [demo.html](https://github.com/mikepack/nerdbox/blob/master/demo.html) has tests.

@jejacks0n @mkitt would love to get some thoughts/eyes on this. It's been plaguing Nerdbox for quite some time.
