### PR TITLE
Use the `container` option from the current Nerdbox instance

### DIFF
--- a/spec/nerdbox/nerdbox_spec.js
+++ b/spec/nerdbox/nerdbox_spec.js
@@ -149,6 +149,13 @@ describe('Nerdbox', function() {
 
       expect(callback).toHaveBeenCalled();
     });
+
+    it('allows overriding options in the constructor', function() {
+      new Nerdbox({container: '<div id="custom-container"></div>'});
+
+      expect($('#custom-container')).toExist();
+      $('#custom-container').remove();
+    });
   });
 
   describe('clicking Nerdbox links', function() {

--- a/src/nerdbox.js
+++ b/src/nerdbox.js
@@ -106,7 +106,7 @@ Nerdbox.prototype._open = function(href) {
 
 Nerdbox.prototype._setup = function() {
   // Add HTML to DOM
-  jQuery('body').append(Nerdbox.options.container);
+  jQuery('body').append(this.options.container);
 
   // Bind click handlers
   var boundOpen = jQuery.proxy(this._openFromLink, this);


### PR DESCRIPTION
Options are applied to the instance in `Nerdbox.init`, so doing this allows us
to override `container` in the constructor.
