### PR TITLE
allows container classes to update when multiple instances

### DIFF
--- a/spec/nerdbox/nerdbox_spec.js
+++ b/spec/nerdbox/nerdbox_spec.js
@@ -134,6 +134,33 @@ describe('Nerdbox', function() {
         expect(classes().indexOf('different')).toBeGreaterThan(-1);
         expect(classes().indexOf('box')).toBeGreaterThan(-1);
       });
+
+      it('has appropriate classes on the container when second instance is opened', function() {
+        Nerdbox.open('', {classes: 'winner chicken'});
+        Nerdbox.close();
+        Nerdbox.open('', {classes: 'dinner sandwich'});
+        var el = $(Nerdbox.options.nerdboxSelector);
+        expect(el.attr("class")).toMatch('dinner')
+        expect(el.attr("class")).toMatch('sandwich')
+        expect(el.attr("class")).not.toMatch('winner')
+        expect(el.attr("class")).not.toMatch('chicken')
+      });
+
+      it('has appropriate classes on the container when 1st instance is re-opened', function() {
+        var nerdbox1 = new Nerdbox({classes: 'winner chicken'});
+        var nerdbox2 = new Nerdbox({classes: 'dinner sandwich'});
+        var el = $(Nerdbox.options.nerdboxSelector);
+        nerdbox1.open('the menu');
+        nerdbox1.close()
+        nerdbox2.open('what is on')
+        nerdbox2.close()
+        nerdbox1.open('the menu');
+
+        expect(el.attr("class")).toMatch('winner')
+        expect(el.attr("class")).toMatch('chicken')
+        expect(el.attr("class")).not.toMatch('dinner')
+        expect(el.attr("class")).not.toMatch('sandwich')
+      });
     });
   });
 

--- a/src/nerdbox.js
+++ b/src/nerdbox.js
@@ -79,7 +79,8 @@ Nerdbox.prototype.init = function(selector, delegate, options) {
 Nerdbox.prototype.open = function(href) {
   var that = this;
 
-  jQuery(this.options.nerdboxSelector).addClass('loading');
+  jQuery(this.options.nerdboxSelector).removeClass().addClass(this._classes());
+  jQuery(this.options.nerdboxSelector).addClass('loading')
   jQuery(this._contentSelector()).html(this.options.loader);
 
   this._fadeIn(function() { that._trigger('opened'); });
@@ -114,7 +115,6 @@ Nerdbox.prototype._setup = function() {
   // Add HTML to DOM
   if( jQuery(this.options.nerdboxSelector).length === 0 ) {
     jQuery(this.options.container).appendTo('body')
-                                  .addClass(this._classes());
   }
 
   // Bind click handlers


### PR DESCRIPTION
we had a case where we had 2 Nerdbox instances on the same page that required their own styling.  Once the container was added to the DOM, the classes wouldn't get updated even when the new instance replaced the Nerdbox content as expected.  setting the the classes outside of the container seems to be the simplest way to achieve this.  
